### PR TITLE
add entrypoint to dockerfile

### DIFF
--- a/DataProcessingService/Dockerfile
+++ b/DataProcessingService/Dockerfile
@@ -7,4 +7,5 @@ RUN npm install
 COPY . .
 EXPOSE 3000
 
-CMD [ "node", "app", "-c", "green" ]
+ENTRYPOINT [ "node", "app" ]
+CMD [ "-c", "green" ]


### PR DESCRIPTION
add entry point to allow the same image to be used for different colors.

`docker run <tag>` will start a "green" server

`docker run <tag> -c blue` will start a "blue" server